### PR TITLE
Use Assertions in the Command Package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin/
 /text-ui-test/ACTUAL.TXT
 text-ui-test/EXPECTED-UNIX.TXT
 text-ui-test/data/saopigTaskList.txt
+data/saopigTaskList.txt

--- a/build.gradle
+++ b/build.gradle
@@ -55,4 +55,5 @@ shadowJar {
 
 run {
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/saopig/command/AddCommand.java
+++ b/src/main/java/saopig/command/AddCommand.java
@@ -34,6 +34,7 @@ public class AddCommand extends Command {
      * @param typeIndex The type of task to be added.
      */
     public AddCommand(String command, int typeIndex) {
+        assert typeIndex == 0 || typeIndex == 1 || typeIndex == 2 : "Invalid type index";
         this.command = command;
         this.typeIndex = typeIndex;
     }
@@ -61,6 +62,7 @@ public class AddCommand extends Command {
     public String addTodoTask(String input, TaskList taskList, Ui ui, Storage storage) {
         try {
             checkValue(input.length(), 6, Integer.MAX_VALUE);
+            assert input.length() >= 6 : "Input length should be at least 6";
             String processedInput = input.substring(5);
             Todo task = new Todo(processedInput);
             taskList.addTodoTask(task);
@@ -97,6 +99,7 @@ public class AddCommand extends Command {
         try {
             StringBuilder response = new StringBuilder();
             checkValue(input.length(), 10, Integer.MAX_VALUE);
+            assert input.length() >= 10 : "Input length should be at least 10";
             String splitInput = input.substring(9);
             String[] splitArguments = splitInput.split(" /by ");
             if (splitArguments.length != 2) {
@@ -162,6 +165,7 @@ public class AddCommand extends Command {
         try {
             StringBuilder response = new StringBuilder();
             checkValue(input.length(), 7, Integer.MAX_VALUE);
+            assert input.length() >= 7 : "Input length should be at least 7";
             String splitInput = input.substring(6);
             String[] splitArguments = splitInput.split("/");
             if (splitArguments.length != 3) {
@@ -169,6 +173,7 @@ public class AddCommand extends Command {
                         + "Whoopsie!\n "
                         + "It seems like you may have forgotten to write the event start or end time ");
             }
+            assert splitArguments.length == 3 : "Split arguments length should be 3";
             String description = splitArguments[0].trim();
             String fromTime = splitArguments[1].trim().substring(5);
             String toTime = splitArguments[2].trim().substring(3);

--- a/src/main/java/saopig/command/DeleteCommand.java
+++ b/src/main/java/saopig/command/DeleteCommand.java
@@ -20,6 +20,7 @@ public class DeleteCommand extends Command {
      * @param typeIndex The type of task to be deleted.
      */
     public DeleteCommand(String command, int typeIndex) {
+        assert typeIndex == 0 : "typeIndex should be 0";
         this.command = command;
         this.typeIndex = typeIndex;
     }
@@ -44,6 +45,7 @@ public class DeleteCommand extends Command {
     public String deleteTask(String input, TaskList taskList, Ui ui, Storage storage) {
         try {
             checkValue(input.length(), 8, Integer.MAX_VALUE);
+            assert input.length() >= 8 : "Input length should be at least 8";
             int index = Integer.parseInt(input.substring(7)) - 1;
             taskList.deleteTask(index);
             storage.saveTaskList(taskList);

--- a/src/main/java/saopig/command/FindCommand.java
+++ b/src/main/java/saopig/command/FindCommand.java
@@ -22,6 +22,7 @@ public class FindCommand extends Command {
      * @param typeIndex The type index.
      */
     public FindCommand(String command, int typeIndex) {
+        assert typeIndex == 0 : "typeIndex should be 0";
         this.command = command;
         this.typeIndex = typeIndex;
     }
@@ -35,6 +36,7 @@ public class FindCommand extends Command {
     private String findTask(String input, TaskList tasks, Ui ui) {
         try {
             checkValue(input.length(), 6, Integer.MAX_VALUE);
+            assert input.length() >= 6 : "Input length should be at least 6";
             String processedInput = input.substring(5);
             ArrayList<Task> matchingTasks = new ArrayList<>();
             for (Task task : tasks.getTasks()) {

--- a/src/main/java/saopig/command/ListCommand.java
+++ b/src/main/java/saopig/command/ListCommand.java
@@ -33,6 +33,7 @@ public class ListCommand extends Command {
      * @param typeIndex The type index.
      */
     public ListCommand(String command, int typeIndex) {
+        assert typeIndex == 0 || typeIndex == 1 : "typeIndex should be 0 or 1";
         this.command = command;
         this.typeIndex = typeIndex;
     }
@@ -59,6 +60,7 @@ public class ListCommand extends Command {
                     + "Whenever you're ready to add tasks, I'll be right here to assist you.\n "
                     + "Let's make it a magical journey together!");
         }
+        assert !taskList.getTasks().isEmpty() : "Task list should not be empty";
         StringBuilder response = new StringBuilder();
         for (int i = 0; i < taskList.getTasks().size(); i++) {
             Task task = taskList.getTasks().get(i);
@@ -84,6 +86,7 @@ public class ListCommand extends Command {
         try {
             StringBuilder response = new StringBuilder();
             checkValue(input.length(), 16, Integer.MAX_VALUE);
+            assert input.length() >= 16 : "Input length should be at least 16";
             String date = input.substring(15);
             response.append("\n" + "Oh, splendid! Let me check my calendar for tasks on ").append(date).append("...");
             LocalDateTime dateTime = LocalDateTime.parse(date + " 00:00", DATE_TIME_FORMATTER);

--- a/src/main/java/saopig/command/MarkCommand.java
+++ b/src/main/java/saopig/command/MarkCommand.java
@@ -6,6 +6,8 @@ import saopig.Ui;
 import saopig.task.Task;
 import saopig.task.TaskList;
 
+import java.util.Objects;
+
 /**
  * Represents a command to mark tasks as done.
  */
@@ -21,6 +23,7 @@ public class MarkCommand extends Command {
      * @param typeIndex The type index.
      */
     public MarkCommand(String command, int typeIndex) {
+        assert typeIndex == 0 || typeIndex == 1 : "typeIndex should be 0 or 1";
         this.command = command;
         this.typeIndex = typeIndex;
     }
@@ -45,9 +48,11 @@ public class MarkCommand extends Command {
         try {
             StringBuilder response = new StringBuilder();
             checkValue(input.length(), 6, Integer.MAX_VALUE);
+            assert input.length() >= 6 : "Input length should be at least 6";
             int index = Integer.parseInt(input.substring(5)) - 1;
             Task task = taskList.getTask(index);
             task.markAsDone();
+            assert Objects.equals(task.getStatusIcon(), "X") : "Task should be marked as done";
             storage.saveTaskList(taskList);
             response.append("\n" + "Oh, splendid! Your task: {")
                     .append(task.toString())
@@ -89,9 +94,11 @@ public class MarkCommand extends Command {
         try {
             StringBuilder response = new StringBuilder();
             checkValue(input.length(), 8, Integer.MAX_VALUE);
+            assert input.length() >= 8 : "Input length should be at least 8";
             int index = Integer.parseInt(input.substring(7)) - 1;
             Task task = taskList.getTask(index);
             task.unmarkAsDone();
+            assert Objects.equals(task.getStatusIcon(), " ") : "Task should be marked as not done";
             storage.saveTaskList(taskList);
             response.append("\n" + "Oh, you've unmarked task: {")
                     .append(task.toString()).append("}?\n ")


### PR DESCRIPTION
Modified the gradle setting to enable Java' assertions at runtime

Assertions have been added to most of the Command classes to help detect whether the type index conforms to the set optional range.

Add assertions after processing the input length to determine if the input still does not conform to the expected specification.